### PR TITLE
Fix build when CC contains parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class build_PyWCSTools_ext(build_ext):
 
         os.chdir(sourceDir)
         cc=setuptools._distutils.ccompiler.new_compiler(setuptools._distutils.ccompiler.get_default_compiler())
-        cc.compiler_so=[sysconfig.get_config_var('CC')]+sysconfig.get_config_var('CFLAGS').split()+sysconfig.get_config_var('CFLAGSFORSHARED').split()
+        cc.compiler_so=sysconfig.get_config_var('CC').split()+sysconfig.get_config_var('CFLAGS').split()+sysconfig.get_config_var('CFLAGSFORSHARED').split()
 
         # Suppress warnings from compiling WCSTools wcssubs-3.9.5
         if "-Wstrict-prototypes" in cc.compiler_so:


### PR DESCRIPTION
The error message is as follows:
```
running build_ext
"cc -pthread" -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -fstack-protector-strong -fno-strict-aliasing -fPIC -c imio.c -o imio.o
error: command 'cc -pthread' failed: No such file or directory

ERROR Backend subprocess exited when trying to invoke build_wheel
*** Error code 1
```